### PR TITLE
Replaced std::thread-based spawn timer with sf::Clock

### DIFF
--- a/SnakeFML/CMakeLists.txt
+++ b/SnakeFML/CMakeLists.txt
@@ -6,7 +6,6 @@ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -std=c++14")
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/cmake")
 
 find_package(SFML 2 REQUIRED graphics window system)
-find_package(Threads)
 
 include_directories(${SFML_INCLUDE_DIR})
 
@@ -27,4 +26,4 @@ set(SRCS
 
 add_executable("${PROJECT_NAME}-exec" ${HDRS} ${SRCS})
 
-target_link_libraries("${PROJECT_NAME}-exec" ${SFML_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT})
+target_link_libraries("${PROJECT_NAME}-exec" ${SFML_LIBRARIES})

--- a/SnakeFML/SnakeFML/Main.cpp
+++ b/SnakeFML/SnakeFML/Main.cpp
@@ -16,7 +16,7 @@ int main()
 
 
 	//hardcode size for now...
-	sf::RenderWindow window(sf::VideoMode(800, 800), "SFML works!");
+	sf::RenderWindow window(sf::VideoMode(800, 800), "SnakeFML");
 
 	float dt = 0; // Delta-Time
 	sf::Clock dtClock;
@@ -24,14 +24,14 @@ int main()
 	//limit to 60 for now. Coil whine is annoying
 	window.setFramerateLimit(60);
 
-	
+
 	// Our menu
 	Button playButton([&]() {
 		gameState = INGAME;
 	});
 	playButton.shape.setSize({ 128 * 3 , 128 });
 	playButton.shape.setPosition(static_cast<sf::Vector2f>(window.getSize()) / 2.f - playButton.shape.getSize() / 2.f); // Center the button
-	
+
 	Button exitButton([&]() {
 		gameState = CLOSING;
 	});
@@ -63,6 +63,7 @@ int main()
 			case E_GAME_STATE::MENU:
 				playButton.processEvent(event);
 				exitButton.processEvent(event);
+				break;
 			default:
 				break;
 			}
@@ -76,7 +77,8 @@ int main()
 			snake.update(dt);
 
 			spawner.checkCollisions(snake);
-			
+			spawner.spawn();
+
 			window.draw(snake);
 			spawner.draw();
 			break;

--- a/SnakeFML/SnakeFML/MouseSpawner.cpp
+++ b/SnakeFML/SnakeFML/MouseSpawner.cpp
@@ -35,16 +35,17 @@ active(true)
 
 void MouseSpawner::spawn()
 {
-	auto xPosition = xDistribution(randomEngine);
-	auto yPosition = yDistribution(randomEngine);
 
 	if (spawnTimer.getElapsedTime().asSeconds() >= spawnInterval())
 	{
 	    spawnTimer.restart();
 
-	    if (size() < maximumSpawnedMice())
+	    if (active && spawnedMice.size() < maximumSpawnedMice())
 	    {
             std::unique_ptr<Mouse> mouse = std::make_unique<Mouse>(nextId);
+
+            auto xPosition = xDistribution(randomEngine);
+            auto yPosition = yDistribution(randomEngine);
 
             mouse->setBodyPosition(xPosition, yPosition);
 
@@ -76,9 +77,4 @@ void MouseSpawner::draw() const
     {
         window->draw(*mouse.second);
     }
-}
-
-std::size_t MouseSpawner::size()
-{
-    return spawnedMice.size();
 }

--- a/SnakeFML/SnakeFML/MouseSpawner.hpp
+++ b/SnakeFML/SnakeFML/MouseSpawner.hpp
@@ -4,8 +4,10 @@
 #include <map>
 #include <memory>
 #include <random>
+
 #include <SFML/Window.hpp>
 #include <SFML/System.hpp>
+
 #include "Mouse.hpp"
 #include "Snake.hpp"
 
@@ -14,14 +16,11 @@ class MouseSpawner final
 public:
 
     MouseSpawner(sf::RenderWindow* window);
-    ~MouseSpawner() = default;
 
     void spawn();
     void checkCollisions(Snake& snake);
 
     void draw() const;
-
-    std::size_t size();
 
 private:
 

--- a/SnakeFML/SnakeFML/MouseSpawner.hpp
+++ b/SnakeFML/SnakeFML/MouseSpawner.hpp
@@ -1,22 +1,20 @@
 #pragma once
 
-#include <atomic>
 #include <cstdint>
 #include <map>
 #include <memory>
-#include <mutex>
 #include <random>
-#include <thread>
 #include <SFML/Window.hpp>
+#include <SFML/System.hpp>
 #include "Mouse.hpp"
 #include "Snake.hpp"
 
-class MouseSpawner
+class MouseSpawner final
 {
 public:
 
     MouseSpawner(sf::RenderWindow* window);
-    ~MouseSpawner();
+    ~MouseSpawner() = default;
 
     void spawn();
     void checkCollisions(Snake& snake);
@@ -25,17 +23,14 @@ public:
 
     std::size_t size();
 
-    bool active();
-
 private:
 
     std::mt19937                                   randomEngine;
     std::uniform_int_distribution<int>             xDistribution;
     std::uniform_int_distribution<int>             yDistribution;
     std::map<std::uint8_t, std::unique_ptr<Mouse>> spawnedMice;
-    std::unique_ptr<std::thread>                   timedSpawner;
+    sf::Clock                                      spawnTimer;
     sf::RenderWindow*                              window;
-    std::atomic_bool                               threadActive;
     std::uint8_t                                   nextId;
-    std::mutex                                     mutex;
+    bool                                           active;
 };


### PR DESCRIPTION
Removed std::thread-based spawn timer and replaced with sf::Clock-based implementation, since it appears std::thread and its related functionality causes issues with MinGW builds. Happy to remove it for this project, since it was unnecessary anyway, but this may be an issue going forward if we ever want to do anything multithreaded so perhaps we could have a discussion as to how to proceed on that front in the future.